### PR TITLE
Fix refresh token validation

### DIFF
--- a/petify-user-service/src/main/java/com/petify/user/service/impl/AuthServiceImpl.java
+++ b/petify-user-service/src/main/java/com/petify/user/service/impl/AuthServiceImpl.java
@@ -97,6 +97,10 @@ public class AuthServiceImpl implements AuthService {
             if (!jwtUtil.isTokenValid(refreshToken)) {
                 throw new BusinessException(401, "刷新令牌无效");
             }
+
+            if (!"refresh".equals(jwtUtil.getTokenType(refreshToken))) {
+                throw new BusinessException(401, "令牌类型错误");
+            }
             
             if (isTokenBlacklisted(jwtUtil.getJwtId(refreshToken))) {
                 throw new BusinessException(401, "刷新令牌已失效");


### PR DESCRIPTION
## Summary
- validate refresh token is actually a refresh token before issuing new access tokens

## Testing
- `mvn -q clean package -DskipTests` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851901a5da4832fa03e3faadb7b53d4